### PR TITLE
补充 hidapi 依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ keyboard>=0.13.5
 pystray>=0.19.0
 Pillow>=10.0.0
 ttkbootstrap>=1.10.0
+hidapi>=0.15.0
  


### PR DESCRIPTION
## Summary
- add `hidapi` to `requirements.txt`
- fix startup failure caused by missing `hid` module after a fresh install

## Test plan
- [x] Run `python -m pip install -r requirements.txt`
- [x] Run `python src/main.py`